### PR TITLE
Added incrementOnFilenameConflict Option 

### DIFF
--- a/confirm-modal.ts
+++ b/confirm-modal.ts
@@ -1,0 +1,42 @@
+import { App, Modal, Setting } from "obsidian";
+
+export class ConfirmModal extends Modal {
+    existingFilename: string;
+    onSubmit: (doOverwrite: boolean) => void;
+
+    constructor(app: App, existingFilename: string, onSubmit: (result: boolean) => void) {
+        super(app);
+        this.existingFilename = existingFilename;
+        this.onSubmit = onSubmit;
+    }
+
+    onOpen() {
+        let { contentEl } = this;
+        contentEl.setText(this.existingFilename + " already exists. Do you want to replace it?");
+
+        new Setting(contentEl)
+            .addButton((btn) =>
+                btn
+                    .setButtonText("Cancel")
+                    .setCta()
+                    .onClick(() => {
+                        this.close();
+                        this.onSubmit(false);
+                    }));
+
+        new Setting(contentEl)
+            .addButton((btn) =>
+                btn
+                    .setButtonText("Replace")
+                    .setCta()
+                    .onClick(() => {
+                        this.close();
+                        this.onSubmit(true);
+                    }));
+    }
+    onClose() {
+        let { contentEl } = this;
+        contentEl.empty();
+    }
+
+}

--- a/global.ts
+++ b/global.ts
@@ -32,7 +32,7 @@ export interface PandocPluginSettings {
     // Export from HTML or from markdown?
     exportFrom: 'html' | 'md',
     // If the output file already exists add an integer increment to the filename. eg. MyNote.docx => MyNote1.docx
-    incrementOnFilenameConflict: boolean,
+    overwriteMode: 'overwrite' | 'confirm' | 'increment',
 }
 
 export const DEFAULT_SETTINGS: PandocPluginSettings = {
@@ -49,7 +49,7 @@ export const DEFAULT_SETTINGS: PandocPluginSettings = {
     outputFolder: null,
     extraArguments: '',
     exportFrom: 'html',
-    incrementOnFilenameConflict: false,
+    overwriteMode: 'overwrite'
 }
 
 export function replaceFileExtension(filename: string, ext: string): string {

--- a/main.ts
+++ b/main.ts
@@ -18,7 +18,13 @@ import * as temp from 'temp';
 
 import render from './renderer';
 import PandocPluginSettingTab from './settings';
-import { PandocPluginSettings, DEFAULT_SETTINGS, replaceFileExtension } from './global';
+import {
+    PandocPluginSettings,
+    DEFAULT_SETTINGS,
+    replaceFileExtension,
+    fileExists,
+    getUniqueFilename
+} from './global';
 export default class PandocPlugin extends Plugin {
     settings: PandocPluginSettings;
     features: { [key: string]: string | undefined } = {};
@@ -94,9 +100,15 @@ export default class PandocPlugin extends Plugin {
         // However, we provide an option to use MD instead to use citations
 
         let outputFile: string = replaceFileExtension(inputFile, extension);
+
         if (this.settings.outputFolder) {
             outputFile = path.join(this.settings.outputFolder, path.basename(outputFile));
         }
+
+        if(this.settings.incrementOnFilenameConflict && (await fileExists(outputFile))) {
+            outputFile = await getUniqueFilename(outputFile, 1);
+        }
+
         const view = this.app.workspace.getActiveViewOfType(MarkdownView);
         
         try {

--- a/settings.ts
+++ b/settings.ts
@@ -140,6 +140,16 @@ export default class PandocPluginSettingTab extends PluginSettingTab {
                 }));
 
         new Setting(containerEl)
+            .setName("Increment filename on conflict")
+            .setDesc("When the output file already exists, add a numerical increment to avoid overwriting the existing file")
+            .addToggle(toggle => toggle
+                .setValue(this.plugin.settings.incrementOnFilenameConflict)
+                .onChange(async (value: boolean) => {
+                    this.plugin.settings.incrementOnFilenameConflict = value;
+                    await this.plugin.saveSettings();
+                }));
+
+        new Setting(containerEl)
             .setName("Extra Pandoc arguments")
             .setDesc("Add extra command line arguments so you can use templates or bibliographies. Newlines are turned into spaces")
             .addTextArea(text => text

--- a/settings.ts
+++ b/settings.ts
@@ -140,12 +140,17 @@ export default class PandocPluginSettingTab extends PluginSettingTab {
                 }));
 
         new Setting(containerEl)
-            .setName("Increment filename on conflict")
-            .setDesc("When the output file already exists, add a numerical increment to avoid overwriting the existing file")
-            .addToggle(toggle => toggle
-                .setValue(this.plugin.settings.incrementOnFilenameConflict)
-                .onChange(async (value: boolean) => {
-                    this.plugin.settings.incrementOnFilenameConflict = value;
+            .setName("Overwrite Mode")
+            .setDesc("Controls what happens when the target output file already exists at the destination")
+            .addDropdown(dropdown => dropdown
+                .addOptions({
+                    "overwrite": "Overwrite existing file",
+                    "confirm": "Confirm before overwriting existing file",
+                    "increment": "Add numerical increment to avoid overwrite",
+                })
+                .setValue(this.plugin.settings.overwriteMode)
+                .onChange(async (value: string) => {
+                    this.plugin.settings.overwriteMode = value as 'overwrite' | 'confirm' | 'increment';
                     await this.plugin.saveSettings();
                 }));
 


### PR DESCRIPTION
Added incrementOnFilenameConflict option to optionally avoid overwriting existing output files.

For example, if pandoc is about to output to "MyFile.docx" but that file already exists, then this option will increment the filename to "MyFile1.docx," or whatever the appropriate increment number is like "MyFile6436.docx".